### PR TITLE
feat: pin the server/client image version

### DIFF
--- a/infra/containers.tf
+++ b/infra/containers.tf
@@ -17,6 +17,6 @@
 # Base images supplied pre-built.
 
 locals {
-  server_image = "gcr.io/${var.image_host_project}/server"
-  client_image = "gcr.io/${var.image_host_project}/client"
+  server_image = "gcr.io/${var.server_image_host}/server:${var.image_version}"
+  client_image = "gcr.io/${var.client_image_host}/client:${var.image_version}"
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -53,6 +53,24 @@ variable "init" {
   default     = true
 }
 
+variable "image_version" {
+  type        = string
+  default     = "v1.1.1"
+  description = "Version of the image to use"
+}
+
+variable "client_image_host" {
+  type        = string
+  default     = "hsa-public/terraform-python-dynamic-webapp"
+  description = "Google Cloud Project that hosts client images"
+}
+
+variable "server_image_host" {
+  type        = string
+  default     = "hsa-public/terraform-python-dynamic-webapp"
+  description = "Google Cloud Project that hosts server images"
+}
+
 # Optional customisation
 
 variable "instance_name" {
@@ -65,12 +83,6 @@ variable "service_name" {
   type        = string
   default     = "server"
   description = "Cloud Run service name"
-}
-
-variable "image_host_project" {
-  type        = string
-  default     = "hsa-public/terraform-python-dynamic-webapp"
-  description = "Google Cloud Project that hosts images"
 }
 
 variable "database_name" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -56,19 +56,19 @@ variable "init" {
 variable "image_version" {
   type        = string
   default     = "v1.1.1"
-  description = "Version of the image to use"
+  description = "Version of the Container Registry image to use"
 }
 
 variable "client_image_host" {
   type        = string
   default     = "hsa-public/terraform-python-dynamic-webapp"
-  description = "Google Cloud Project that hosts client images"
+  description = "Container Registry that hosts the client image (PROJECT_ID[/folder])"
 }
 
 variable "server_image_host" {
   type        = string
   default     = "hsa-public/terraform-python-dynamic-webapp"
-  description = "Google Cloud Project that hosts server images"
+  description = "Container Registry that hosts the server image (PROJECT_ID[/folder])"
 }
 
 # Optional customisation


### PR DESCRIPTION
This adds the ability for this repo to track specific versions of the avocano repo. 

Allows avocano to work on feature velocity and merge to main, then specifically bumping this repo when ready. 