### PR TITLE
feat(infra): migrate server to cloud run v2 resource

### DIFF
--- a/infra/jobs.tf
+++ b/infra/jobs.tf
@@ -17,7 +17,7 @@
 resource "google_cloud_run_v2_job" "setup" {
   name         = var.random_suffix ? "setup-${random_id.suffix.hex}" : "setup"
   location     = var.region
-  launch_stage = "BETA"
+  launch_stage = "GA"
 
   labels = var.labels
 
@@ -109,7 +109,7 @@ resource "google_cloud_run_v2_job" "client" {
 
   name         = var.random_suffix ? "client-${random_id.suffix.hex}" : "client"
   location     = var.region
-  launch_stage = "BETA"
+  launch_stage = "GA"
 
   labels = var.labels
 

--- a/infra/jobs.tf
+++ b/infra/jobs.tf
@@ -120,7 +120,7 @@ resource "google_cloud_run_v2_job" "client" {
         image = local.client_image
         env {
           name  = "SERVICE_NAME"
-          value = google_cloud_run_service.server.name
+          value = google_cloud_run_v2_service.server.name
         }
         env {
           name  = "REGION"

--- a/infra/jobs.tf
+++ b/infra/jobs.tf
@@ -15,9 +15,8 @@
  */
 
 resource "google_cloud_run_v2_job" "setup" {
-  name         = var.random_suffix ? "setup-${random_id.suffix.hex}" : "setup"
-  location     = var.region
-  launch_stage = "GA"
+  name     = var.random_suffix ? "setup-${random_id.suffix.hex}" : "setup"
+  location = var.region
 
   labels = var.labels
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  server_url = google_cloud_run_service.server.status[0].url
+  server_url = google_cloud_run_v2_service.server.uri
 }
 
 output "firebase_url" {
@@ -41,7 +41,7 @@ output "usage" {
     This deployment is now ready for use!
     https://${var.project_id}.web.app
     API Login:
-    ${google_cloud_run_service.server.status[0].url}/admin
+    ${google_cloud_run_v2_service.server.uri}/admin
     Username: admin
     Password: ${google_secret_manager_secret_version.django_admin_password.secret_data}
     EOF

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -15,8 +15,8 @@
  */
 
 resource "google_cloud_run_v2_service" "server" {
-  name     = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
-  location = var.region
+  name         = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
+  location     = var.region
   launch_stage = "BETA"
 
   template {

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -15,8 +15,8 @@
  */
 
 resource "google_cloud_run_v2_service" "server" {
-  name         = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
-  location     = var.region
+  name     = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
+  location = var.region
 
   template {
     service_account = google_service_account.server.email

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -31,12 +31,21 @@ resource "google_cloud_run_v2_service" "server" {
           }
         }
       }
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
     }
     labels = var.labels
     annotations = {
-      "autoscaling.knative.dev/maxScale"      = "100"
-      "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.postgres.connection_name
-      "run.googleapis.com/client-name"        = "terraform"
+      "autoscaling.knative.dev/maxScale" = "100"
+      "run.googleapis.com/client-name"   = "terraform"
+    }
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.postgres.connection_name]
+      }
     }
   }
   traffic {

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -37,10 +37,6 @@ resource "google_cloud_run_v2_service" "server" {
       }
     }
     labels = var.labels
-    annotations = {
-      "autoscaling.knative.dev/maxScale" = "100"
-      "run.googleapis.com/client-name"   = "terraform"
-    }
     volumes {
       name = "cloudsql"
       cloud_sql_instance {

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -17,7 +17,6 @@
 resource "google_cloud_run_v2_service" "server" {
   name         = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
   location     = var.region
-  launch_stage = "BETA"
 
   template {
     service_account = google_service_account.server.email

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -14,39 +14,34 @@
  * limitations under the License.
  */
 
-resource "google_cloud_run_service" "server" {
-  name                       = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
-  location                   = var.region
-  autogenerate_revision_name = true
+resource "google_cloud_run_v2_service" "server" {
+  name     = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
+  location = var.region
 
   template {
-    spec {
-      service_account_name = google_service_account.server.email
-      containers {
-        image = local.server_image
-        env {
-          name = "DJANGO_ENV"
-          value_from {
-            secret_key_ref {
-              name = google_secret_manager_secret.django_settings.secret_id
-              key  = "latest"
-            }
+    service_account = google_service_account.server.email
+    containers {
+      image = local.server_image
+      env {
+        name = "DJANGO_ENV"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.django_settings.secret_id
+            version = "latest"
           }
         }
       }
     }
-    metadata {
-      labels = var.labels
-      annotations = {
-        "autoscaling.knative.dev/maxScale"      = "100"
-        "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.postgres.connection_name
-        "run.googleapis.com/client-name"        = "terraform"
-      }
+    labels = var.labels
+    annotations = {
+      "autoscaling.knative.dev/maxScale"      = "100"
+      "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.postgres.connection_name
+      "run.googleapis.com/client-name"        = "terraform"
     }
   }
   traffic {
-    percent         = 100
-    latest_revision = true
+    percent = 100
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
 
   depends_on = [
@@ -64,8 +59,8 @@ data "google_iam_policy" "noauth" {
 }
 
 resource "google_cloud_run_service_iam_policy" "server_noauth" {
-  location    = google_cloud_run_service.server.location
-  project     = google_cloud_run_service.server.project
-  service     = google_cloud_run_service.server.name
+  location    = google_cloud_run_v2_service.server.location
+  project     = google_cloud_run_v2_service.server.project
+  service     = google_cloud_run_v2_service.server.name
   policy_data = data.google_iam_policy.noauth.policy_data
 }

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -17,6 +17,7 @@
 resource "google_cloud_run_v2_service" "server" {
   name     = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
   location = var.region
+  launch_stage = "BETA"
 
   template {
     service_account = google_service_account.server.email


### PR DESCRIPTION
this unlocks the ability to use startup and liveness checks (without
requiring the beta TF provider)
