### PR TITLE
fix: update to avocano 1.6.0 and use DJANGO_SUPERUSER_PASSWORD with setup job

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -47,7 +47,7 @@ Functional examples are included in the
 | client\_image\_host | Container Registry that hosts the client image (PROJECT\_ID[/folder]) | `string` | `"hsa-public/terraform-python-dynamic-webapp"` | no |
 | database\_name | Cloud SQL database name | `string` | `"django"` | no |
 | database\_username | Cloud SQL database name | `string` | `"server"` | no |
-| image\_version | Version of the Container Registry image to use | `string` | `"v1.5.0"` | no |
+| image\_version | Version of the Container Registry image to use | `string` | `"v1.6.0"` | no |
 | init | Initialize database? | `bool` | `true` | no |
 | instance\_name | Cloud SQL Instance name | `string` | `"psql"` | no |
 | labels | A set of key/value label pairs to assign to the resources deployed by this blueprint. | `map(string)` | `{}` | no |

--- a/infra/jobs.tf
+++ b/infra/jobs.tf
@@ -36,7 +36,7 @@ resource "google_cloud_run_v2_job" "setup" {
           }
         }
         env {
-          name = "ADMIN_PASSWORD"
+          name = "DJANGO_SUPERUSER_PASSWORD"
           value_source {
             secret_key_ref {
               secret  = google_secret_manager_secret.django_admin_password.secret_id

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -55,7 +55,7 @@ variable "init" {
 
 variable "image_version" {
   type        = string
-  default     = "v1.5.0"
+  default     = "v1.6.0"
   description = "Version of the Container Registry image to use"
 }
 


### PR DESCRIPTION
Introduced in https://github.com/GoogleCloudPlatform/avocano/pull/179