### PR TITLE
fix: use google_project_iam_member to manage IAM permissions

### DIFF
--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -48,28 +48,43 @@ resource "google_service_account" "compute" {
   count        = var.init ? 1 : 0
 }
 
-# Both the server and Cloud Build can access the database
+# The Cloud Run server can access the database
 resource "google_project_iam_member" "server_permissions" {
   project    = var.project_id
   role       = "roles/cloudsql.client"
-  members    = [local.server_SA, local.automation_SA]
-  depends_on = [google_service_account.server, google_service_account.automation]
+  member     = local.server_SA
+  depends_on = [google_service_account.server]
 }
 
+# Cloud Build can access the database
+resource "google_project_iam_member" "build_permissions" {
+  project    = var.project_id
+  role       = "roles/cloudsql.client"
+  member     = local.automation_SA
+  depends_on = [google_service_account.automation]
+}
 
 # Server needs introspection permissions
 resource "google_project_iam_member" "server_introspection" {
   project    = var.project_id
   role       = "roles/run.viewer"
-  members    = [local.server_SA, local.client_SA]
-  depends_on = [google_service_account.server, google_service_account.client]
+  member     = local.server_SA
+  depends_on = [google_service_account.server]
+}
+
+# Client needs introspection permissions
+resource "google_project_iam_member" "client_introspection" {
+  project    = var.project_id
+  role       = "roles/run.viewer"
+  member     = local.client_SA
+  depends_on = [google_service_account.client]
 }
 
 # Client may need permission to deploy the front end
 resource "google_project_iam_member" "client_permissions" {
   project    = var.project_id
   role       = "roles/firebasehosting.admin"
-  members    = [local.client_SA]
+  member     = local.client_SA
   depends_on = [google_service_account.client]
 }
 
@@ -77,7 +92,7 @@ resource "google_project_iam_member" "client_permissions" {
 resource "google_project_iam_member" "computestartup_permissions" {
   project    = var.project_id
   role       = "roles/run.developer"
-  members    = ["serviceAccount:${google_service_account.compute[0].email}"]
+  member     = "serviceAccount:${google_service_account.compute[0].email}"
   depends_on = [google_service_account.compute]
   count      = var.init ? 1 : 0
 }
@@ -86,6 +101,6 @@ resource "google_project_iam_member" "computestartup_permissions" {
 resource "google_project_iam_member" "server_traceagent" {
   project    = var.project_id
   role       = "roles/cloudtrace.agent"
-  members    = [local.server_SA]
+  member     = local.server_SA
   depends_on = [google_service_account.server]
 }

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -49,7 +49,7 @@ resource "google_service_account" "compute" {
 }
 
 # Both the server and Cloud Build can access the database
-resource "google_project_iam_binding" "server_permissions" {
+resource "google_project_iam_member" "server_permissions" {
   project    = var.project_id
   role       = "roles/cloudsql.client"
   members    = [local.server_SA, local.automation_SA]
@@ -58,7 +58,7 @@ resource "google_project_iam_binding" "server_permissions" {
 
 
 # Server needs introspection permissions
-resource "google_project_iam_binding" "server_introspection" {
+resource "google_project_iam_member" "server_introspection" {
   project    = var.project_id
   role       = "roles/run.viewer"
   members    = [local.server_SA, local.client_SA]
@@ -66,7 +66,7 @@ resource "google_project_iam_binding" "server_introspection" {
 }
 
 # Client may need permission to deploy the front end
-resource "google_project_iam_binding" "client_permissions" {
+resource "google_project_iam_member" "client_permissions" {
   project    = var.project_id
   role       = "roles/firebasehosting.admin"
   members    = [local.client_SA]
@@ -74,7 +74,7 @@ resource "google_project_iam_binding" "client_permissions" {
 }
 
 # GCE instance needs access to start Jobs
-resource "google_project_iam_binding" "computestartup_permissions" {
+resource "google_project_iam_member" "computestartup_permissions" {
   project    = var.project_id
   role       = "roles/run.developer"
   members    = ["serviceAccount:${google_service_account.compute[0].email}"]
@@ -83,7 +83,7 @@ resource "google_project_iam_binding" "computestartup_permissions" {
 }
 
 # Server needs to write to Cloud Trace
-resource "google_project_iam_binding" "server_traceagent" {
+resource "google_project_iam_member" "server_traceagent" {
   project    = var.project_id
   role       = "roles/cloudtrace.agent"
   members    = [local.server_SA]


### PR DESCRIPTION
Fixes #41 

I considered using `for_each` to apply the role to a list of members for the several cases of parallel permissions, but ultimately decided that would create a terraform state migration that would add maintenance overhead, and whether to use that approach or not is a pretty even split on complexity vs. conciseness.