### PR TITLE
performance: tune healthcheck for server behavior

### DIFF
--- a/infra/service.tf
+++ b/infra/service.tf
@@ -57,10 +57,10 @@ resource "google_cloud_run_v2_service" "server" {
       startup_probe {
         http_get {
           initial_delay_seconds = 5
-          period_seconds = 3
-          timeout_seconds = 2
-          failure_threshold = 5
-          path = "/ready"
+          period_seconds        = 3
+          timeout_seconds       = 2
+          failure_threshold     = 5
+          path                  = "/ready"
         }
       }
       liveness_probe {

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -56,6 +56,10 @@ resource "google_cloud_run_v2_service" "server" {
       }
       startup_probe {
         http_get {
+          initial_delay_seconds = 5
+          period_seconds = 3
+          timeout_seconds = 2
+          failure_threshold = 5
           path = "/ready"
         }
       }

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -55,12 +55,12 @@ resource "google_cloud_run_v2_service" "server" {
         mount_path = "/cloudsql"
       }
       startup_probe {
+        initial_delay_seconds = 5
+        period_seconds        = 3
+        timeout_seconds       = 2
+        failure_threshold     = 5
         http_get {
-          initial_delay_seconds = 5
-          period_seconds        = 3
-          timeout_seconds       = 2
-          failure_threshold     = 5
-          path                  = "/ready"
+          path = "/ready"
         }
       }
       liveness_probe {


### PR DESCRIPTION
This PR fixes the blueprint's exaggerated cold start penalty, originally documented in https://github.com/GoogleCloudPlatform/avocano/issues/74.

## Change

* Delay 5 seconds to give server a chance to start
* Begin polling on a 3 second interval
* Fail out on 5 fails
* Noticing some queries take around 1.1 seconds, setting timeout to 2.

## Impact

![Screenshot 2023-05-01 at 4 50 46 PM](https://user-images.githubusercontent.com/283489/235550928-5e9930b8-7e44-46b7-900a-6c8851b0d15b.png)

This is showing cold start page load taking just over 8 seconds, and that the initial request for site_config is taking 7.47 seconds. The screenshot also shows "7.33 seconds of "stalled" time, which may well be cold start/waiting for ready check.

Based on the updated settings in this PR, the first healtcheck at 5 seconds is successful. We should follow-up in the future with more optimization and a data-based approach to these numbers, but this is much better than the current slowness we're encountering of ~23 second first response