### PR TITLE
fix: prevent website not found errors after firebase deploy completes

### DIFF
--- a/infra/examples/simple_example/README.md
+++ b/infra/examples/simple_example/README.md
@@ -13,6 +13,7 @@ This example illustrates how to use the `dynamic-python-webapp` module.
 
 | Name | Description |
 |------|-------------|
+| firebase\_url | Firebase URL |
 | usage | Connection details for the project |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/infra/examples/simple_example/outputs.tf
+++ b/infra/examples/simple_example/outputs.tf
@@ -19,3 +19,8 @@ output "usage" {
   description = "Connection details for the project"
   value       = module.dynamic-python-webapp.usage
 }
+
+output "firebase_url" {
+  description = "Firebase URL"
+  value       = module.dynamic-python-webapp.firebase_url
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -15,12 +15,13 @@
  */
 
 locals {
-  server_url = google_cloud_run_v2_service.server.uri
+  server_url   = google_cloud_run_v2_service.server.uri
+  firebase_url = "https://${var.project_id}.web.app"
 }
 
 output "firebase_url" {
   description = "Firebase URL"
-  value       = "https://${var.project_id}.web.app"
+  value       = local.firebase_url
 }
 
 locals {
@@ -55,7 +56,7 @@ output "usage" {
   sensitive   = true
   value       = <<-EOF
     This deployment is now ready for use!
-    https://${var.project_id}.web.app
+    ${local.firebase_url}
     API Login:
     ${google_cloud_run_v2_service.server.uri}/admin
     Username: admin

--- a/infra/postdeployment.tf
+++ b/infra/postdeployment.tf
@@ -81,9 +81,9 @@ resource "google_compute_instance" "gce_init" {
 echo "Running init database migration"
 gcloud beta run jobs execute ${google_cloud_run_v2_job.setup.name} --wait --project ${var.project_id} --region ${var.region}
 
-
 echo "Running client deploy"
 gcloud beta run jobs execute ${google_cloud_run_v2_job.client.name} --wait --project ${var.project_id} --region ${var.region}
+curl -X PURGE "${local.client_url}/"
 
 echo "Warm up API"
 curl ${local.server_url}/api/products/?warmup

--- a/infra/postdeployment.tf
+++ b/infra/postdeployment.tf
@@ -83,7 +83,7 @@ gcloud beta run jobs execute ${google_cloud_run_v2_job.setup.name} --wait --proj
 
 echo "Running client deploy"
 gcloud beta run jobs execute ${google_cloud_run_v2_job.client.name} --wait --project ${var.project_id} --region ${var.region}
-curl -X PURGE "${local.client_url}/"
+curl -X PURGE "${local.firebase_url}/"
 
 echo "Warm up API"
 curl ${local.server_url}/api/products/?warmup

--- a/infra/test/integration/go.mod
+++ b/infra/test/integration/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.5.1
+	github.com/gruntwork-io/terratest v0.41.11
 	github.com/stretchr/testify v1.8.2
 )
 
@@ -30,7 +31,6 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
-	github.com/gruntwork-io/terratest v0.41.11 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.7.0 // indirect

--- a/infra/test/integration/simple_example/simple_example_test.go
+++ b/infra/test/integration/simple_example/simple_example_test.go
@@ -35,12 +35,6 @@ func TestSimpleExample(t *testing.T) {
 	example.DefineApply(func(assert *assert.Assertions) {
 		example.DefaultApply(assert)
 
-		// Temporary: Output debugging.
-		m := terraform.OutputAll(t, example.GetTFOptions())
-		for k, v := range m {
-			t.Logf("Output %s: %s\n", k, v)
-		}
-
 		// Use of this module as part of a Jump Start Solution triggers a URL
 		// request when terraform apply completes. This primes the Firebase Hosting
 		// CDN with a platform-supplied 404 page.

--- a/infra/test/integration/simple_example/simple_example_test.go
+++ b/infra/test/integration/simple_example/simple_example_test.go
@@ -35,6 +35,12 @@ func TestSimpleExample(t *testing.T) {
 	example.DefineApply(func(assert *assert.Assertions) {
 		example.DefaultApply(assert)
 
+		// Temporary: Output debugging.
+		m := terraform.OutputAll(t, example.GetTFOptions())
+		for k, v := range m {
+			t.Logf("Output %s: %s\n", k, v)
+		}
+
 		// Use of this module as part of a Jump Start Solution triggers a URL
 		// request when terraform apply completes. This primes the Firebase Hosting
 		// CDN with a platform-supplied 404 page.

--- a/infra/test/integration/simple_example/simple_example_test.go
+++ b/infra/test/integration/simple_example/simple_example_test.go
@@ -47,8 +47,12 @@ func TestSimpleExample(t *testing.T) {
 		// a simpler HTTP request.
 		//
 		// https://github.com/GoogleCloudPlatform/terraform-dynamic-python-webapp/issues/64
-		u := terraform.OutputRequired(t, example.GetTFOptions(), "firebase_url")
-		assertResponseContains(assert, u, "Site Not Found")
+		firebase_url := terraform.OutputRequired(t, example.GetTFOptions(), "firebase_url")
+		fragment := "Site Not Found"
+		code, responseBody, err := httpGetRequest(firebase_url)
+		assert.Nil(err)
+		assert.Equal(code, 404)
+		assert.Containsf(responseBody, fragment, "couldn't find %q in response body", fragment)
 	})
 
 	example.DefineVerify(func(assert *assert.Assertions) {


### PR DESCRIPTION
Progress towards #64 

This change is expected to restore frontend UI loading after firebase deploy completes. It does not address the gap between terraform apply and firebase deploy.
