### PR TITLE
fix: remove startup probe

### DIFF
--- a/infra/service.tf
+++ b/infra/service.tf
@@ -54,11 +54,6 @@ resource "google_cloud_run_v2_service" "server" {
         name       = "cloudsql"
         mount_path = "/cloudsql"
       }
-      startup_probe {
-        http_get {
-          path = "/ready"
-        }
-      }
       liveness_probe {
         http_get {
           path = "/healthy"


### PR DESCRIPTION
Replaces #66 


Remove the startup probe, based on data showing this can currently affect cold-start time. 