### PR TITLE
fix: restore missing dependencies

### DIFF
--- a/app/placeholder/Dockerfile
+++ b/app/placeholder/Dockerfile
@@ -17,6 +17,7 @@
 ARG PROJECT_ID=YOURPROJECTID
 FROM gcr.io/$PROJECT_ID/firebase
 
+RUN apk add gettext
 RUN npm install -g json
 COPY . ./
 

--- a/app/placeholder/Dockerfile
+++ b/app/placeholder/Dockerfile
@@ -17,6 +17,7 @@
 ARG PROJECT_ID=YOURPROJECTID
 FROM gcr.io/$PROJECT_ID/firebase
 
+RUN npm install -g json
 COPY . ./
 
 ENTRYPOINT ./placeholder-deploy.sh


### PR DESCRIPTION
Bug: #78 is failing. 

Logs: after apply, the client website is displaying 404, not the expected placeholder

Diagnosis: the placeholder deployment was failing due to missing `json` package.

Cause: the placeholder image was automatically re-built when #58 was merged.  Previously it was using a manually-built image that was tagged "latest" that was not the latest version. `json` dependency was removed from the Dockerfile erroneously, and only after updating the image does it present on other deployments. 

Fix: Having the image built from the same repo as changes that use it means there needs to be a segmented deployment process, where in-flight images can be used, rather than always 'latest' 

Temp workaround: once this PR is created, the image will be built with this fix, which will unblock all builds and deployments. 

Update: the image was also missing the `envsubstr` package, which wasn't noticed as there's no current mechanism to test deployments of the placeholder in the same PR the placeholder is being updated