### PR TITLE
feat: Ignore health checks for tracing purposes

### DIFF
--- a/infra/service.tf
+++ b/infra/service.tf
@@ -50,6 +50,10 @@ resource "google_cloud_run_v2_service" "server" {
         name  = "OTEL_TRACES_EXPORTER"
         value = "gcp_trace"
       }
+      env {
+        name  = "OTEL_PYTHON_EXCLUDED_URLS"
+        value = "healthy"
+      }
       volume_mounts {
         name       = "cloudsql"
         mount_path = "/cloudsql"


### PR DESCRIPTION
Health checks tend to pollute the trace list and often cause other traces to get dropped when the appserver rate limits automatic traces.