### PR TITLE
ci: use higher CPU machine type in Cloud Build

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -71,6 +71,8 @@ steps:
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage teardown --verbose']
+options:
+  machineType: e2-highcpu-8
 tags:
 - 'ci'
 - 'integration'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -72,7 +72,7 @@ steps:
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage teardown --verbose']
 options:
-  machineType: e2-highcpu-8
+  machineType: E2_HIGHCPU_8
 tags:
 - 'ci'
 - 'integration'


### PR DESCRIPTION
This PR switches from the Cloud Build machine default of `e2-medium` with 1 vCPU and 4 GB memory (and no provisioning delay) to an `e2highcpu-8` with 8 vCPU and 8 GB memory (and unspecified provisioning delay).

The goal is to evaluate the test run time difference, and compute a rough cost trade-off. If we like it, this PR may progress to non-draft, otherwise the PR will be closed as a completed experiment.