### PR TITLE
experiment: use e2-standard-2 for postdeployment

### DIFF
--- a/infra/postdeployment.tf
+++ b/infra/postdeployment.tf
@@ -49,7 +49,7 @@ resource "google_compute_instance" "gce_init" {
   ]
 
   name           = var.random_suffix ? "head-start-initialize-${random_id.suffix.hex}" : "head-start-initialize"
-  machine_type   = "n1-standard-1"
+  machine_type   = "e2-standard2"
   zone           = var.zone
   desired_status = "RUNNING" # https://github.com/GoogleCloudPlatform/terraform-dynamic-python-webapp/pull/75#issuecomment-1547198414
 

--- a/infra/postdeployment.tf
+++ b/infra/postdeployment.tf
@@ -49,7 +49,7 @@ resource "google_compute_instance" "gce_init" {
   ]
 
   name           = var.random_suffix ? "head-start-initialize-${random_id.suffix.hex}" : "head-start-initialize"
-  machine_type   = "e2-standard2"
+  machine_type   = "e2-standard-2"
   zone           = var.zone
   desired_status = "RUNNING" # https://github.com/GoogleCloudPlatform/terraform-dynamic-python-webapp/pull/75#issuecomment-1547198414
 


### PR DESCRIPTION
This experiment is to confirm the test suite has no issues switching to an e2 GCE instance type in advance of considering changing from n1-standard-1 to a more available type such as the e2 series.