### PR TITLE
testing: cft test run without --verbose

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -26,51 +26,51 @@ steps:
 # Initialize all tests, then run two parallel sets of tests
 - id: init-all
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run all --stage init --verbose']
+  args: ['/bin/bash', '-c', 'cft test run all --stage init']
 
 # Simple example - one deployment per project
 - id: simple-example-init
   waitFor: ['init-all']
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage init --verbose']
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage init']
 - id: simple-example-apply
   waitFor: ['simple-example-init']
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage apply --verbose']
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage apply']
 - id: simple-example-verify
   waitFor: ['simple-example-apply']
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage verify --verbose']
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage verify']
 - id: simple-example-teardown
   waitFor: ['simple-example-verify']
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage teardown --verbose']
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage teardown']
 
 # Suffix example - supports multiple deployments per project
 - id: suffix-example-init
   waitFor: ['init-all']
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage init --verbose']
+  args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage init']
 - id: suffix-example-apply
   waitFor: ['suffix-example-init']
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage apply --verbose']
+  args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage apply']
 - id: suffix-example-verify
   waitFor: ['suffix-example-apply']
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage verify --verbose']
+  args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage verify']
 - id: suffix-example-teardown
   waitFor: ['suffix-example-verify']
   dir: infra
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage teardown --verbose']
+  args: ['/bin/bash', '-c', 'cft test run TestSuffixExample --stage teardown']
 tags:
 - 'ci'
 - 'integration'


### PR DESCRIPTION
The --verbose flag is causing sensitive terraform outputs to be displayed in plaintext as part of test runs. This is an initial experiment to see if simply disabling verbose hides sensitive information without hindering troubleshooting.