### PR TITLE
feat: migrate postdeployment to data http

### DIFF
--- a/app/init/Dockerfile
+++ b/app/init/Dockerfile
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# Execute with "docker run --build-arg PROJECT_ID=$PROJECT_ID ..."
-ARG PROJECT_ID=YOURPROJECTID
-FROM gcr.io/$PROJECT_ID/firebase
-
-RUN apk add gettext curl
-RUN npm install -g json
-COPY . ./
-
-ENTRYPOINT ./placeholder-deploy.sh
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+COPY init-execute.sh .
+ENTRYPOINT ./init-execute.sh

--- a/app/init/README.md
+++ b/app/init/README.md
@@ -1,0 +1,10 @@
+# Init
+
+This folder contains the source for a container image that runs the tasks required to setup the application on first deployment. 
+
+The container is designed to be executed as a Cloud Run job, with the `roles/run.developer` role, to run the `init-execute.sh` script: 
+
+ * execute the `setup` job, [primes the the database](https://github.com/GoogleCloudPlatform/avocano/blob/main/server/scripts/prime_database.sh) script
+ * execute the `client` job, that runs the [client deployment](https://github.com/GoogleCloudPlatform/avocano/blob/main/client/docker-deploy.sh)
+ * purges cache and warms API. 
+

--- a/app/init/README.md
+++ b/app/init/README.md
@@ -1,10 +1,10 @@
 # Init
 
-This folder contains the source for a container image that runs the tasks required to setup the application on first deployment. 
+This folder contains the source for a container image that runs the tasks required to setup the application on first deployment.
 
-The container is designed to be executed as a Cloud Run job, with the `roles/run.developer` role, to run the `init-execute.sh` script: 
+The container is designed to be executed as a Cloud Run job, with the `roles/run.developer` role, to run the `init-execute.sh` script:
 
  * execute the `setup` job, [primes the the database](https://github.com/GoogleCloudPlatform/avocano/blob/main/server/scripts/prime_database.sh) script
  * execute the `client` job, that runs the [client deployment](https://github.com/GoogleCloudPlatform/avocano/blob/main/client/docker-deploy.sh)
- * purges cache and warms API. 
+ * purges cache and warms API.
 

--- a/app/init/init-execute.sh
+++ b/app/init/init-execute.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to assist in Dockerfile-based deployments.
+# any errors? exit immediately.
+set -e
+
+# escape if project_id not defined (mandatory, required later)
+if [[ -z $PROJECT_ID ]]; then
+   echo "PROJECT_ID not defined. Cannot deploy. Exiting."
+   exit 1
+fi
+
+# escape if firebase_url not defined (mandatory, required later)
+if [[ -z $FIREBASE_URL ]]; then
+   echo "FIREBASE_URL not defined. Cannot deploy. Exiting."
+   exit 1
+fi
+
+# Define common defaults, all overrideable.
+REGION="${REGION:-us-central1}"
+SETUP_JOB="${SETUP_JOB:-setup}"
+CLIENT_JOB="${CLIENT_JOB:-client}"
+
+echo "*** Executing initization job ***"
+echo "PROJECT_ID:   $PROJECT_ID"
+echo "REGION:       $REGION"
+echo "SETUP JOB:    $SETUP_JOB"
+echo "CLIENT JOB:   $CLIENT_JOB"
+echo "FIREBASE URL: $FIREBASE_URL"
+echo "SERVER URL:   $SERVER_URL"
+echo ""
+
+echo "Running init database migration..."
+gcloud run jobs execute $SETUP_JOB --wait --project $PROJECT_ID --region $REGION
+
+echo "Running client deploy..."
+gcloud run jobs execute $CLIENT_JOB --wait --project $PROJECT_ID --region $REGION
+
+echo "Purge Firebase cache"
+echo curl -X PURGE "${FIREBASE_URL}/"
+
+echo "Warm up API"
+curl "${SERVER_URL}/api/products/?warmup"

--- a/app/init/init-execute.sh
+++ b/app/init/init-execute.sh
@@ -44,10 +44,10 @@ echo "SERVER URL:   $SERVER_URL"
 echo ""
 
 echo "Running init database migration..."
-gcloud run jobs execute $SETUP_JOB --wait --project $PROJECT_ID --region $REGION
+gcloud run jobs execute "$SETUP_JOB" --wait --project "$PROJECT_ID" --region "$REGION"
 
 echo "Running client deploy..."
-gcloud run jobs execute $CLIENT_JOB --wait --project $PROJECT_ID --region $REGION
+gcloud run jobs execute "$CLIENT_JOB" --wait --project "$PROJECT_ID" --region "$REGION"
 
 echo "Purge Firebase cache"
 echo curl -X PURGE "${FIREBASE_URL}/"

--- a/app/init/init-image.cloudbuild.yaml
+++ b/app/init/init-image.cloudbuild.yaml
@@ -12,13 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build placeholder site code into container
 
-# Execute with "docker run --build-arg PROJECT_ID=$PROJECT_ID ..."
-ARG PROJECT_ID=YOURPROJECTID
-FROM gcr.io/$PROJECT_ID/firebase
+steps:
+  - id: build
+    name: "gcr.io/cloud-builders/docker"
+    dir: app/init
+    args:
+      [
+        "build",
+        "-t",
+        "gcr.io/$PROJECT_ID/$_IMAGE_NAME",
+        ".",
+      ]
 
-RUN apk add gettext curl
-RUN npm install -g json
-COPY . ./
+images:
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME
 
-ENTRYPOINT ./placeholder-deploy.sh
+substitutions:
+  _IMAGE_NAME: avocano-init
+
+options:
+  dynamic_substitutions: true

--- a/app/placeholder/placeholder-deploy.sh
+++ b/app/placeholder/placeholder-deploy.sh
@@ -25,7 +25,7 @@ fi
 
 # Only run the placeholder script if the site has been deployed before.
 # Check if the firebase url has "Site Not Found" (the pre-deployment state)
-if curl $FIREBASE_URL | grep -q "Site Not Found"; then
+if curl "$FIREBASE_URL" | grep -q "Site Not Found"; then
     echo "Firebase site $FIREBASE_URL hasn't been deployed before, so it needs a placeholder."
 else
     echo "Firebase site $FIREBASE_URL has been deployed before. Not going to deploy placeholder. Exiting."

--- a/app/placeholder/placeholder-deploy.sh
+++ b/app/placeholder/placeholder-deploy.sh
@@ -17,6 +17,21 @@
 # any errors? exit immediately.
 set -e
 
+# escape if firebase_url not defined (mandatory, required later)
+if [[ -z $FIREBASE_URL ]]; then
+    echo "FIREBASE_URL not defined. Cannot deploy. Exiting."
+    exit 1
+fi
+
+# Only run the placeholder script if the site has been deployed before.
+# Check if the firebase url has "Site Not Found" (the pre-deployment state)
+if curl $FIREBASE_URL | grep -q "Site Not Found"; then
+    echo "Firebase site $FIREBASE_URL hasn't been deployed before, so it needs a placeholder."
+else
+    echo "Firebase site $FIREBASE_URL has been deployed before. Not going to deploy placeholder. Exiting."
+    exit 0
+fi
+
 # if deploying with a suffix (from infra/jobs.tf), adjust the config to suit the custom site
 # https://firebase.google.com/docs/hosting/multisites#set_up_deploy_targets
 if [[ -n $SUFFIX ]]; then
@@ -24,7 +39,7 @@ if [[ -n $SUFFIX ]]; then
     UPDATED=true
 
     # Use template file to generate configuration
-    envsubst  < firebaserc.tmpl > .firebaserc
+    envsubst <firebaserc.tmpl >.firebaserc
     echo "Customised .firebaserc created to support site."
     cat .firebaserc
 fi
@@ -35,6 +50,10 @@ if [[ -n $UPDATED ]]; then
     cat firebase.json
 fi
 
+# Finally, deploy the application
 echo "Deploying placeholder to Firebase..."
-
 firebase deploy --project "$PROJECT_ID" --only hosting
+
+# Setup for greater chances of success by explicitly purging cache
+echo "Purging firebase cache"
+curl -X PURGE "${FIREBASE_URL}/"

--- a/infra/containers.tf
+++ b/infra/containers.tf
@@ -19,5 +19,6 @@
 locals {
   server_image      = "gcr.io/${var.server_image_host}/server:${var.image_version}"
   client_image      = "gcr.io/${var.client_image_host}/client:${var.image_version}"
-  placeholder_image = "gcr.io/hsa-public/avocano-placeholder:latest"
+  placeholder_image = "gcr.io/hsa-public/avocano-placeholder:postjsscurl" # TODO(glasnt): revert to tag "latest"
+  init_image        = "gcr.io/hsa-public/avocano-init:postjsscurl" # TODO(glasnt): revert to tag "latest"
 }

--- a/infra/containers.tf
+++ b/infra/containers.tf
@@ -20,5 +20,5 @@ locals {
   server_image      = "gcr.io/${var.server_image_host}/server:${var.image_version}"
   client_image      = "gcr.io/${var.client_image_host}/client:${var.image_version}"
   placeholder_image = "gcr.io/hsa-public/avocano-placeholder:postjsscurl" # TODO(glasnt): revert to tag "latest"
-  init_image        = "gcr.io/hsa-public/avocano-init:postjsscurl" # TODO(glasnt): revert to tag "latest"
+  init_image        = "gcr.io/hsa-public/avocano-init:postjsscurl"        # TODO(glasnt): revert to tag "latest"
 }

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -41,9 +41,9 @@ resource "google_service_account" "automation" {
   depends_on   = [module.project_services]
 }
 
-resource "google_service_account" "compute" {
-  account_id   = var.random_suffix ? "compute-startup-${random_id.suffix.hex}" : "compute-startup"
-  display_name = "Head Start App Compute Instance SA"
+resource "google_service_account" "init" {
+  account_id   = var.random_suffix ? "init-startup-${random_id.suffix.hex}" : "init-startup"
+  display_name = "Jump Start App Init SA"
   depends_on   = [module.project_services]
   count        = var.init ? 1 : 0
 }
@@ -88,12 +88,12 @@ resource "google_project_iam_member" "client_permissions" {
   depends_on = [google_service_account.client]
 }
 
-# GCE instance needs access to start Jobs
-resource "google_project_iam_member" "computestartup_permissions" {
+# Init process needs access to start Jobs
+resource "google_project_iam_member" "initstartup_permissions" {
   project    = var.project_id
   role       = "roles/run.developer"
-  member     = "serviceAccount:${google_service_account.compute[0].email}"
-  depends_on = [google_service_account.compute]
+  member     = "serviceAccount:${google_service_account.init[0].email}"
+  depends_on = [google_service_account.init]
   count      = var.init ? 1 : 0
 }
 

--- a/infra/jobs.tf
+++ b/infra/jobs.tf
@@ -144,32 +144,3 @@ resource "google_cloud_run_v2_job" "client" {
   ]
 }
 
-
-resource "google_cloud_run_v2_job" "placeholder" {
-  name     = var.random_suffix ? "placeholder-${random_id.suffix.hex}" : "placeholder"
-  location = var.region
-
-  labels = var.labels
-
-  template {
-    template {
-      service_account = google_service_account.client.email
-      containers {
-        image = local.placeholder_image
-        env {
-          name  = "PROJECT_ID"
-          value = var.project_id
-        }
-
-        env {
-          name  = "SUFFIX"
-          value = var.random_suffix ? random_id.suffix.hex : ""
-        }
-      }
-    }
-  }
-
-  depends_on = [
-    module.project_services
-  ]
-}

--- a/infra/postdeployment.tf
+++ b/infra/postdeployment.tf
@@ -19,7 +19,7 @@
 data "google_client_config" "current" {
 }
 
-# Job that uses pre-built docker image to deploy a placeholder website. 
+# Job that uses pre-built docker image to deploy a placeholder website.
 resource "google_cloud_run_v2_job" "placeholder" {
   name     = var.random_suffix ? "placeholder-${random_id.suffix.hex}" : "placeholder"
   location = var.region
@@ -56,7 +56,7 @@ resource "google_cloud_run_v2_job" "placeholder" {
 }
 
 
-# execute the job by calling the API directly. 
+# execute the job by calling the API directly.
 data "http" "execute_placeholder_job" {
   url    = "https://${var.region}-run.googleapis.com/v2/projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.placeholder.name}:run"
   method = "POST"
@@ -124,7 +124,7 @@ resource "google_cloud_run_v2_job" "init" {
 }
 
 
-# execute the job, once it and other dependencies exit. 
+# execute the job, once it and other dependencies exit.
 data "http" "execute_init_job" {
   count = var.init ? 1 : 0
 

--- a/infra/postdeployment.tf
+++ b/infra/postdeployment.tf
@@ -29,7 +29,6 @@ resource "google_cloud_run_v2_job" "placeholder" {
   template {
     template {
       service_account = google_service_account.client.email
-      max_retries     = 1
       containers {
         image = local.placeholder_image
 
@@ -81,7 +80,6 @@ resource "google_cloud_run_v2_job" "init" {
   template {
     template {
       service_account = google_service_account.init[0].email
-      max_retries     = 1
       containers {
         image = local.init_image
 

--- a/infra/postdeployment.tf
+++ b/infra/postdeployment.tf
@@ -56,7 +56,8 @@ resource "google_cloud_run_v2_job" "placeholder" {
 }
 
 
-# execute the job by calling the API directly.
+# execute the job by calling the API directly. Intended side-effect
+# tflint-ignore: terraform_unused_declarations
 data "http" "execute_placeholder_job" {
   url    = "https://${var.region}-run.googleapis.com/v2/projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.placeholder.name}:run"
   method = "POST"
@@ -124,7 +125,8 @@ resource "google_cloud_run_v2_job" "init" {
 }
 
 
-# execute the job, once it and other dependencies exit.
+# execute the job, once it and other dependencies exit. Intended side-effect.
+# tflint-ignore: terraform_unused_declarations
 data "http" "execute_init_job" {
   count = var.init ? 1 : 0
 

--- a/infra/postdeployment.tf
+++ b/infra/postdeployment.tf
@@ -52,6 +52,11 @@ resource "google_cloud_run_v2_job" "placeholder" {
   depends_on = [
     module.project_services
   ]
+
+  # work around, b/292021282
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 
@@ -120,6 +125,11 @@ resource "google_cloud_run_v2_job" "init" {
   depends_on = [
     module.project_services
   ]
+
+  # work around, b/292021282
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -29,6 +29,7 @@ variable "region" {
 
 # HSA
 
+# tflint-ignore: terraform_unused_declarations
 variable "zone" {
   type        = string
   description = "GCP zone for provisioning zonal resources."


### PR DESCRIPTION
Replaces compute engine and associated resources with a `data "http"` call to the Cloud Run API

Requires moving the logic from the metadata startup scripts to within the containers for placeholder, and a new container for `init`. Uses the same permissions, only the service account has renamed to reflect the usage. 


Merge blocked on: 

- [ ] updating the `containers.tf` to reference the `latest` images (manually created`:postjsscurl` tagged images used while testing)
- [ ] confirming functionality
- [ ] removing any compute engine APIs/permissions based on removed resources (without removing infra-required APIs)

Lint issues: 

- [x] Warning: data "http" "execute_placeholder_job" is declared but not used (terraform_unused_declarations)
- [x] Warning: data "http" "execute_init_job" is declared but not used (terraform_unused_declarations)
- [x] Warning: variable "zone" is declared but not used (terraform_unused_declarations)

Build failures: 

- [ ] Cannot delete job 'placeholder-eca5' because there are 1 execution(s) of the job running. (started after reading `data.http.execute_placeholder_job`)
- [ ] Cannot delete job 'init-eca5' because there are 1 execution(s) of the job running. (started after reading `data.http.execute_init_job`)
