### PR TITLE
fix: revert use Uniform Bucket Level Access in Cloud Storage

### DIFF
--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -21,10 +21,6 @@ resource "google_storage_bucket" "media" {
   storage_class = "REGIONAL"
   force_destroy = true
 
-  # Avoid conflict with constraints/storage.uniformBucketLevelAccess.
-  # This is recommended: https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
-  uniform_bucket_level_access = true
-
   labels = var.labels
 }
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/terraform-dynamic-python-webapp#115

The underlying django-storages library does not support uniform bucket level access by default. If it is supported, it's not documented. For now, reverting this change.