### PR TITLE
fix: pin minimum provider

### DIFF
--- a/infra/examples/simple_example/versions.tf
+++ b/infra/examples/simple_example/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.40"
     }
   }
   required_version = ">= 0.13"

--- a/infra/examples/suffix_example/versions.tf
+++ b/infra/examples/suffix_example/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.40"
     }
   }
   required_version = ">= 0.13"

--- a/infra/test/setup/versions.tf
+++ b/infra/test/setup/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.25.0"
+      version = ">= 5.40"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.25.0"
+      version = ">= 5.40"
     }
   }
 }

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      version = ">= 5.40, < 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.53, < 6"
+      version = ">= 5.40, < 6"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Fixes issue resolved in https://github.com/hashicorp/terraform-provider-google/releases/tag/v5.40.0 where Cloud SQL instances don't have plan drift ([#18962](https://togithub.com/hashicorp/terraform-provider-google/pull/18962))