### PR TITLE
fix: update minimum provider, deletion_protection field for cloud run

### DIFF
--- a/infra/examples/simple_example/versions.tf
+++ b/infra/examples/simple_example/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.40"
+      version = "~> 6"
     }
   }
 }

--- a/infra/examples/suffix_example/versions.tf
+++ b/infra/examples/suffix_example/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.40"
+      version = "~> 6"
     }
   }
 }

--- a/infra/jobs.tf
+++ b/infra/jobs.tf
@@ -21,6 +21,8 @@ resource "google_cloud_run_v2_job" "migrate" {
 
   labels = var.labels
 
+  deletion_protection = false
+
   template {
     template {
       service_account = google_service_account.automation.email

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -18,6 +18,8 @@ resource "google_cloud_run_v2_service" "server" {
   name     = var.random_suffix ? "${var.service_name}-${random_id.suffix.hex}" : var.service_name
   location = var.region
 
+  deletion_protection = false
+
   template {
     service_account = google_service_account.server.email
     containers {

--- a/infra/test/setup/versions.tf
+++ b/infra/test/setup/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.40"
+      version = ">= 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.40"
+      version = ">= 6"
     }
   }
 }

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.40, < 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.40, < 7"
+      version = ">= 6, < 7"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Resolves #275 

Updates minimum provider version for all instances, ensures services can be `terraform destroy`'d (important for testing and solution deletion)