### PR TITLE
fix: extend timeout waiting for job completion

### DIFF
--- a/infra/test/integration/testhelper.go
+++ b/infra/test/integration/testhelper.go
@@ -107,7 +107,7 @@ func AssertExample(t *testing.T) {
 
 				return false, nil
 			}
-			utils.Poll(t, isJobFinished, 10, time.Second*10)
+			utils.Poll(t, isJobFinished, 10, time.Second*20)
 
 			// The API must return a list that includes our flagship product
 			assertResponseContains(t, assert, serviceURL+"/api/products/", flagshipProduct)


### PR DESCRIPTION
Should resolve test issues in #345 

b/420741565

The `client` job appears to be finishing just after the current timeout, so extend the time between timeout checks to ensure a large enough window to wait (but still checking frequently enough to make sure once it is ready, it can continue)