### PR TITLE
fix: prevent scaling plan changes from blocking CI

### DIFF
--- a/infra/service.tf
+++ b/infra/service.tf
@@ -90,7 +90,7 @@ resource "google_cloud_run_v2_service" "server" {
 
   lifecycle {
     ignore_changes = [
-      template[0].scaling,
+      scaling,
     ]
   }
 }

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -87,6 +87,12 @@ resource "google_cloud_run_v2_service" "server" {
   depends_on = [
     google_secret_manager_secret_version.django_settings
   ]
+
+  lifecycle {
+    ignore_changes = [
+      template[0].scaling,
+    ]
+  }
 }
 
 

--- a/infra/test/integration/testhelper.go
+++ b/infra/test/integration/testhelper.go
@@ -107,7 +107,7 @@ func AssertExample(t *testing.T) {
 
 				return false, nil
 			}
-			utils.Poll(t, isJobFinished, 10, time.Second*20)
+			utils.Poll(t, isJobFinished, 10, time.Second*30)
 
 			// The API must return a list that includes our flagship product
 			assertResponseContains(t, assert, serviceURL+"/api/products/", flagshipProduct)


### PR DESCRIPTION
Observed in https://github.com/GoogleCloudPlatform/terraform-dynamic-python-webapp/runs/67362203830

There may be a change to the provider that is causing scaling arguments to change between creation and re-planning when left unchanged: 

```
   ~ resource "google_cloud_run_v2_service" "server" {
         id                      = "projects/ci-dynamic-python-webapp-dc63/locations/us-central1/services/server"
         name                    = "server"
         # (33 unchanged attributes hidden)
 
       - scaling {
           - manual_instance_count = 0 -> null
           - min_instance_count    = 0 -> null
             # (1 unchanged attribute hidden)
         }
 
         # (2 unchanged blocks hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
```

This change should allow for the template.scaling changes to be ignored, this letting PRs like #425 for unrelated changes pass. 